### PR TITLE
Update vsphere_ontap_best_practices.adoc

### DIFF
--- a/virtualization/vsphere_ontap_best_practices.adoc
+++ b/virtualization/vsphere_ontap_best_practices.adoc
@@ -415,7 +415,7 @@ The following table lists NFS versions and supported features.
 |Yes (enhanced with vSphere 6.5 and later to support AES, krb5i)
 |Multipathing support
 |No
-|ESXi 7.0U3f and later support session trunking with ONTAP 9.12.1RC1 and later
+|No
 |===
 
 == FlexGroup


### PR DESCRIPTION
ESXi session trunking qualification is being at least temporarily delayed, so need to remove it from the doc.